### PR TITLE
Add QEMU setup in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary
- set up QEMU before Docker Buildx to allow ARM builds

## Testing
- `bun run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_685586312864832e9be9cdd5bc33fe2f