### PR TITLE
Fix missing ARM target for Tauri build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Add ARM64 Rust target
+        run: rustup target add aarch64-unknown-linux-gnu
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
@@ -104,8 +107,10 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PKG_CONFIG_ALLOW_CROSS: "1"
         with:
           args: "--target aarch64-unknown-linux-gnu"
+          useCross: true
           tagName: v${{ github.event.inputs.version }}
           releaseName: "App v${{ github.event.inputs.version }} for Debian"
           releaseBody: "Release for Linux Debian. Download and install the package for your Debian system."


### PR DESCRIPTION
## Summary
- add `rustup target add aarch64-unknown-linux-gnu` so the ARM64 Tauri build succeeds
- enable `useCross` with `PKG_CONFIG_ALLOW_CROSS=1` for ARM64 Tauri build

## Testing
- `npm test` *(fails: Missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_e_685585249704832e828b2a62841f2743