### PR TITLE
Fix cross image and packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Add ARM64 Rust target
+        run: rustup target add aarch64-unknown-linux-gnu
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
@@ -45,8 +48,21 @@ jobs:
 
       - name: Install Tauri dependencies for Debian
         run: |
-          sudo apt update
-          sudo apt install -y libwebkit2gtk-4.1-dev \
+          sudo rm -f /etc/apt/sources.list.d/* /etc/apt/sources.list /etc/apt/apt-mirrors.txt
+          . /etc/os-release
+          CODENAME=${UBUNTU_CODENAME:-$(lsb_release -sc)}
+          sudo tee /etc/apt/sources.list.d/ubuntu-amd64.list >/dev/null <<EOF
+          deb [arch=amd64] http://archive.ubuntu.com/ubuntu $CODENAME main restricted universe multiverse
+          deb [arch=amd64] http://archive.ubuntu.com/ubuntu $CODENAME-updates main restricted universe multiverse
+          deb [arch=amd64] http://archive.ubuntu.com/ubuntu $CODENAME-backports main restricted universe multiverse
+          deb [arch=amd64] http://security.ubuntu.com/ubuntu $CODENAME-security main restricted universe multiverse
+          EOF
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            gcc-aarch64-linux-gnu \
+            g++-aarch64-linux-gnu \
             build-essential \
             curl \
             wget \
@@ -104,6 +120,12 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PKG_CONFIG_ALLOW_CROSS: "1"
+          PKG_CONFIG_PATH: "/usr/lib/aarch64-linux-gnu/pkgconfig"
+          PKG_CONFIG_SYSROOT_DIR: "/"
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: "aarch64-linux-gnu-gcc"
+          CC_aarch64_unknown_linux_gnu: "aarch64-linux-gnu-gcc"
+          AR_aarch64_unknown_linux_gnu: "aarch64-linux-gnu-ar"
         with:
           args: "--target aarch64-unknown-linux-gnu"
           tagName: v${{ github.event.inputs.version }}
@@ -159,48 +181,19 @@ jobs:
           name: tauri-arm64
           path: ./docker-artifacts/arm64
 
-      - name: Build and push AMD64 image
+      - name: Build and push multi-arch Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             DEBIAN_VERSION=bookworm
             BUILDKIT_INLINE_CACHE=1
-            APP_ARTIFACT=docker-artifacts/amd64/tauri-amd64.tar.gz
           tags: |
-            ghcr.io/${{ env.REPO_LOWERCASE }}/app:amd64
-            ghcr.io/${{ env.REPO_LOWERCASE }}/app:${{ github.event.inputs.version }}-amd64
+            ghcr.io/${{ env.REPO_LOWERCASE }}/app:latest
+            ghcr.io/${{ env.REPO_LOWERCASE }}/app:${{ github.event.inputs.version }}
           cache-from: |
             type=gha
           cache-to: |
             type=gha,mode=max
-
-      - name: Build and push ARM64 image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          platforms: linux/arm64
-          build-args: |
-            DEBIAN_VERSION=bookworm
-            BUILDKIT_INLINE_CACHE=1
-            APP_ARTIFACT=docker-artifacts/arm64/tauri-arm64.tar.gz
-          tags: |
-            ghcr.io/${{ env.REPO_LOWERCASE }}/app:arm64
-            ghcr.io/${{ env.REPO_LOWERCASE }}/app:${{ github.event.inputs.version }}-arm64
-          cache-from: |
-            type=gha
-          cache-to: |
-            type=gha,mode=max
-
-      - name: Create multi-arch manifest
-        run: |
-          docker buildx imagetools create -t ghcr.io/${{ env.REPO_LOWERCASE }}/app:latest \
-            ghcr.io/${{ env.REPO_LOWERCASE }}/app:amd64 \
-            ghcr.io/${{ env.REPO_LOWERCASE }}/app:arm64
-
-          docker buildx imagetools create -t ghcr.io/${{ env.REPO_LOWERCASE }}/app:${{ github.event.inputs.version }} \
-            ghcr.io/${{ env.REPO_LOWERCASE }}/app:${{ github.event.inputs.version }}-amd64 \
-            ghcr.io/${{ env.REPO_LOWERCASE }}/app:${{ github.event.inputs.version }}-arm64

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,15 @@
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/bookworm-aarch64-unknown-linux-gnu:latest"
+pre-build = [
+  "apt-get update",
+  "apt-get install -y --no-install-recommends \
+    libwebkit2gtk-4.1-dev:arm64 \
+    libgtk-3-dev:arm64 \
+    libxdo-dev:arm64 \
+    libssl-dev:arm64 \
+    libayatana-appindicator3-dev:arm64 \
+    librsvg2-dev:arm64 \
+    libsoup-3.0-dev:arm64 \
+    libjavascriptcoregtk-4.1-dev:arm64"
+]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 ARG DEBIAN_VERSION=bookworm
-ARG APP_ARTIFACT
 
 FROM debian:${DEBIAN_VERSION}-slim AS runtime
 
@@ -18,8 +17,8 @@ RUN useradd -ms /bin/bash appuser
 
 WORKDIR /app
 
-ARG APP_ARTIFACT
-COPY ${APP_ARTIFACT} /tmp/app.tar.gz
+ARG TARGETARCH
+COPY docker-artifacts/${TARGETARCH}/tauri-${TARGETARCH}.tar.gz /tmp/app.tar.gz
 RUN tar -xzf /tmp/app.tar.gz -C /app && rm /tmp/app.tar.gz
 
 # Copy static icons


### PR DESCRIPTION
## Summary
- use bookworm cross image for ARM64 builds
- install required GTK packages in a single apt command for Cross
- ensure ARM64 dev libraries are installed in Cross container
- install cross-compiler toolchain for ARM64 and configure linker
- build multi-arch Docker image in one step

## Testing
- `npm test` *(fails: Missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_e_685585249704832e828b2a62841f2743