### PR TITLE
Enable ARM cross compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,36 +106,15 @@ jobs:
           name: tauri-amd64
           path: tauri-amd64.tar.gz
 
+      - name: Install cross
+        run: cargo install --git https://github.com/cross-rs/cross --locked --package cross
+
       - name: Build Tauri App for ARM64
-        uses: pguyot/arm-runner-action@v2.6.5
-        with:
-          base_image: https://dietpi.com/downloads/images/DietPi_RPi5-ARMv8-Bookworm.img.xz
-          cpu: cortex-a72
-          bind_mount_repository: true
-          image_additional_mb: 10240
-          optimize_image: no
-          commands: |
-            set -e
-            export HOME=/root
-            export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
-            apt-get update -y --allow-releaseinfo-change
-            apt-get autoremove -y
-            apt-get install -y --no-install-recommends --no-install-suggests \
-              curl libwebkit2gtk-4.1-dev build-essential libssl-dev \
-              libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev \
-              patchelf libfuse2 file unzip xz-utils
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            if [ -f "$HOME/.cargo/env" ]; then
-              . "$HOME/.cargo/env"
-            else
-              export PATH="$HOME/.cargo/bin:$PATH"
-            fi
-            curl -fsSL https://bun.sh/install | bash
-            export BUN_INSTALL="$HOME/.bun"
-            export PATH="$BUN_INSTALL/bin:$PATH"
-            cd /github/workspace
-            bun install
-            bun run tauri build -- --verbose
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO: cross
+        run: |
+          bun run tauri build --target aarch64-unknown-linux-gnu -- --verbose
 
       - name: Archive ARM64 build
         run: |

--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ Since TypeScript cannot handle type information for `.vue` imports, they are shi
 2. Reload the VS Code window by running `Developer: Reload Window` from the command palette.
 
 You can learn more about Take Over mode [here](https://github.com/johnsoncodehk/volar/discussions/471).
+
+## Cross compilation
+
+This project uses [cross](https://github.com/cross-rs/cross) to build ARM binaries on CI. You can build locally with:
+
+```bash
+cargo install --git https://github.com/cross-rs/cross --locked --package cross
+CARGO=cross bun run tauri build --target aarch64-unknown-linux-gnu
+```


### PR DESCRIPTION
## Summary
- update build workflow to compile ARM binaries using cross-rs
- document how to build with cross locally
- fix cross installation step

## Testing
- `cargo check` *(fails: network blocked)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6856cd1c7e74832e93e53180b3635107