### PR TITLE
Fix cross build config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Add ARM64 Rust target
+        run: rustup target add aarch64-unknown-linux-gnu
+
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -59,8 +62,7 @@ jobs:
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
-            gcc-aarch64-linux-gnu \
-            g++-aarch64-linux-gnu \
+            pkgconf \
             build-essential \
             curl \
             wget \
@@ -106,36 +108,24 @@ jobs:
           name: tauri-amd64
           path: tauri-amd64.tar.gz
 
+      - name: Install cross
+        run: cargo install --git https://github.com/cross-rs/cross --locked cross
+
+      - name: Clean build artifacts
+        run: cargo clean --manifest-path src-tauri/Cargo.toml
+
       - name: Build Tauri App for ARM64
-        uses: pguyot/arm-runner-action@v2.6.5
-        with:
-          base_image: https://dietpi.com/downloads/images/DietPi_RPi5-ARMv8-Bookworm.img.xz
-          cpu: cortex-a72
-          bind_mount_repository: true
-          image_additional_mb: 10240
-          optimize_image: no
-          commands: |
-            set -e
-            export HOME=/root
-            export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
-            apt-get update -y --allow-releaseinfo-change
-            apt-get autoremove -y
-            apt-get install -y --no-install-recommends --no-install-suggests \
-              curl libwebkit2gtk-4.1-dev build-essential libssl-dev \
-              libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev \
-              patchelf libfuse2 file unzip xz-utils
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            if [ -f "$HOME/.cargo/env" ]; then
-              . "$HOME/.cargo/env"
-            else
-              export PATH="$HOME/.cargo/bin:$PATH"
-            fi
-            curl -fsSL https://bun.sh/install | bash
-            export BUN_INSTALL="$HOME/.bun"
-            export PATH="$BUN_INSTALL/bin:$PATH"
-            cd /github/workspace
-            bun install
-            bun run tauri build -- --verbose
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO: cross
+          TAURI_FCARGO: cross
+          TAURI_CARGO: cross
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          AR_aarch64_unknown_linux_gnu: aarch64-linux-gnu-ar
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          PKG_CONFIG_ALLOW_CROSS: '1'
+        run: |
+          bun run tauri build --target aarch64-unknown-linux-gnu -- --verbose
 
       - name: Archive ARM64 build
         run: |

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,20 @@
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+  "dpkg --add-architecture arm64",
+  "apt-get update",
+  "apt-get install -y --no-install-recommends \
+      libwebkit2gtk-4.1-dev:arm64 \
+      libgtk-3-dev:arm64 \
+      libayatana-appindicator3-dev:arm64 \
+      librsvg2-dev:arm64 \
+      libssl-dev:arm64 \
+      libxdo-dev:arm64 \
+      pkgconf \
+      pkg-config-aarch64-linux-gnu \
+      curl wget file xz-utils",
+]
+
+[target.aarch64-unknown-linux-gnu.env]
+CC_aarch64_unknown_linux_gnu = "aarch64-linux-gnu-gcc"
+AR_aarch64_unknown_linux_gnu = "aarch64-linux-gnu-ar"
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = "aarch64-linux-gnu-gcc"

--- a/README.md
+++ b/README.md
@@ -14,3 +14,23 @@ Since TypeScript cannot handle type information for `.vue` imports, they are shi
 2. Reload the VS Code window by running `Developer: Reload Window` from the command palette.
 
 You can learn more about Take Over mode [here](https://github.com/johnsoncodehk/volar/discussions/471).
+
+## Cross compilation
+
+This project uses [cross](https://github.com/cross-rs/cross) and the accompanying `Cross.toml` configuration to build ARM binaries on CI. You can build locally with:
+
+```bash
+cargo install --git https://github.com/cross-rs/cross --locked cross
+rustup target add aarch64-unknown-linux-gnu
+cargo clean --manifest-path src-tauri/Cargo.toml
+CARGO=cross TAURI_CARGO=cross TAURI_FCARGO=cross \
+CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar \
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+  bun run tauri build --target aarch64-unknown-linux-gnu
+```
+
+The `Cross.toml` file installs the GTK and WebKit ARM64 dependencies along with
+`pkgconf` and `pkg-config-aarch64-linux-gnu` inside the cross container. It uses
+`dpkg --add-architecture arm64` so the required packages like
+`libgtk-3-dev:arm64` can be installed.


### PR DESCRIPTION
## Summary
- set TAURI_CARGO and cross compiler env vars when building ARM64 in CI
- note additional env vars in cross compilation docs
- export the same env vars from Cross.toml

## Testing
- ❌ `cargo check --manifest-path src-tauri/Cargo.toml` *(failed to download dependencies due to network restrictions)*
- ✅ `bun test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6856cd1c7e74832e93e53180b3635107