### PR TITLE
Add libsoup3 dependencies to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
+            libsoup-3.0-dev \
             pkgconf \
             build-essential \
             curl \
@@ -87,6 +88,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev:arm64 \
             libgtk-3-dev:arm64 \
+            libsoup-3.0-dev:arm64 \
             libayatana-appindicator3-dev:arm64 \
             librsvg2-dev:arm64 \
             libssl-dev:arm64 \


### PR DESCRIPTION
## Summary
- fix build by including libsoup3 dev packages in GitHub workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857c7f011a8832eab3c114690bc1c26