### PR TITLE
Fix arm64 build dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
           # Add ARM64 architecture and install cross-compilation tools
           RUN dpkg --add-architecture arm64 && \
               apt-get update && \
-              apt-get install -y \
+              apt-get install -y --no-install-recommends \
                 gcc-aarch64-linux-gnu \
                 g++-aarch64-linux-gnu \
                 libc6-dev-arm64-cross \
@@ -139,7 +139,8 @@ jobs:
                 libgtk-3-dev:arm64 \
                 libayatana-appindicator3-dev:arm64 \
                 librsvg2-dev:arm64 \
-                libxdo-dev:arm64
+                libxdo-dev:arm64 && \
+              rm -rf /var/lib/apt/lists/*
           
           # Install Rust target and Tauri CLI
           RUN rustup target add aarch64-unknown-linux-gnu && \


### PR DESCRIPTION
## Summary
- avoid pulling in recommended packages in the arm64 build
- clean apt lists after installation

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68580757dd58832e8ee41a94978e58b7