### PR TITLE
Fix arm64 build dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,16 +130,20 @@ jobs:
           # Add ARM64 architecture and install cross-compilation tools
           RUN dpkg --add-architecture arm64 && \
               apt-get update && \
-              apt-get install -y \
+              apt-get install -y --no-install-recommends \
                 gcc-aarch64-linux-gnu \
                 g++-aarch64-linux-gnu \
                 libc6-dev-arm64-cross \
-                libwebkit2gtk-4.1-dev:arm64 \
+                build-essential \
+                curl \
+                wget \
+                file \
+                libwebkit2gtk-4.1-dev \
+                libxdo-dev \
                 libssl-dev:arm64 \
-                libgtk-3-dev:arm64 \
-                libayatana-appindicator3-dev:arm64 \
-                librsvg2-dev:arm64 \
-                libxdo-dev:arm64
+                libayatana-appindicator3-dev \
+                librsvg2-dev && \
+              rm -rf /var/lib/apt/lists/*
           
           # Install Rust target and Tauri CLI
           RUN rustup target add aarch64-unknown-linux-gnu && \
@@ -166,11 +170,13 @@ jobs:
         run: |
           docker run --rm \
             -v $PWD:/project \
-            -v /project/node_modules \
+            -v $HOME/.cargo/registry:/root/.cargo/registry \
+            -v $HOME/.cargo/git:/root/.cargo/git \
+            -v $PWD/node_modules:/project/node_modules \
             -e GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
             tauri-cross \
             bash -c "
-              cd /project/src-tauri && 
+              cd /project/src-tauri &&
               cargo tauri build --target aarch64-unknown-linux-gnu --verbose
             "
 


### PR DESCRIPTION
## Summary
- install tauri prerequisites in the cross build Dockerfile
- mount host `node_modules` when running the arm64 Docker build so `bun run build` works inside the container
- share Cargo cache directories with the Docker container so dependencies aren't downloaded again

## Testing
- ❌ `cargo test --manifest-path src-tauri/Cargo.toml --locked` *(failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68580757dd58832e8ee41a94978e58b7