### PR TITLE
Fix arm64 build dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,13 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          shared-key: arm64
+          cache-on-failure: true
+
 
       - name: Install frontend dependencies and build
         run: |
@@ -130,16 +137,20 @@ jobs:
           # Add ARM64 architecture and install cross-compilation tools
           RUN dpkg --add-architecture arm64 && \
               apt-get update && \
-              apt-get install -y \
+              apt-get install -y --no-install-recommends \
                 gcc-aarch64-linux-gnu \
                 g++-aarch64-linux-gnu \
                 libc6-dev-arm64-cross \
-                libwebkit2gtk-4.1-dev:arm64 \
+                build-essential \
+                curl \
+                wget \
+                file \
+                libwebkit2gtk-4.1-dev \
+                libxdo-dev \
                 libssl-dev:arm64 \
-                libgtk-3-dev:arm64 \
-                libayatana-appindicator3-dev:arm64 \
-                librsvg2-dev:arm64 \
-                libxdo-dev:arm64
+                libayatana-appindicator3-dev \
+                librsvg2-dev && \
+              rm -rf /var/lib/apt/lists/*
           
           # Install Rust target and Tauri CLI
           RUN rustup target add aarch64-unknown-linux-gnu && \
@@ -166,11 +177,15 @@ jobs:
         run: |
           docker run --rm \
             -v $PWD:/project \
-            -v /project/node_modules \
+            -v $HOME/.cargo:/usr/local/cargo \
+            -v $PWD/src-tauri/target:/project/src-tauri/target \
+            -v $PWD/node_modules:/project/node_modules \
+            -e CARGO_HOME=/usr/local/cargo \
+            -e TAURI_SKIP_BUILD=true \
             -e GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
             tauri-cross \
             bash -c "
-              cd /project/src-tauri && 
+              cd /project/src-tauri &&
               cargo tauri build --target aarch64-unknown-linux-gnu --verbose
             "
 


### PR DESCRIPTION
## Summary
- install tauri prerequisites in the cross build Dockerfile
- mount host `node_modules` when running the arm64 Docker build so `bun run build` works inside the container
- share Cargo cache directories with the Docker container so dependencies aren't downloaded again
- skip rebuilding the frontend when building the arm64 artifact
- mount the `src-tauri/target` directory in the ARM64 build container to reuse compiled artifacts
- cache arm64 Cargo dependencies and mount them to `/usr/local/cargo`
- reuse cargo cache in docker build by mounting entire `.cargo`

## Testing
- ❌ `cargo test --manifest-path src-tauri/Cargo.toml --locked` *(failed to download crates)*


------
https://chatgpt.com/codex/tasks/task_e_68580757dd58832e8ee41a94978e58b7