### PR TITLE
Fix bun path for ARM64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,66 +112,75 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          shared-key: arm64
+          cache-on-failure: true
+
 
       - name: Install frontend dependencies and build
         run: |
           bun install
           bun run build
 
-      - name: Create cross-compilation Dockerfile
+      - name: Create ARM64 build Dockerfile
         run: |
-          cat > Dockerfile.cross << 'EOF'
+          cat > Dockerfile.cross <<'EOF'
           FROM rust:bookworm
-          
-          # Install Node.js and Bun
+
+          # Install Bun
+          ENV BUN_INSTALL=/usr/local/bun
           RUN curl -fsSL https://bun.sh/install | bash
-          ENV PATH="/root/.bun/bin:$PATH"
-          
-          # Add ARM64 architecture and install cross-compilation tools
-          RUN dpkg --add-architecture arm64 && \
-              apt-get update && \
-              apt-get install -y \
-                gcc-aarch64-linux-gnu \
-                g++-aarch64-linux-gnu \
-                libc6-dev-arm64-cross \
-                libwebkit2gtk-4.1-dev:arm64 \
-                libssl-dev:arm64 \
-                libgtk-3-dev:arm64 \
-                libayatana-appindicator3-dev:arm64 \
-                librsvg2-dev:arm64 \
-                libxdo-dev:arm64
-          
-          # Install Rust target and Tauri CLI
-          RUN rustup target add aarch64-unknown-linux-gnu && \
-              cargo install tauri-cli
-          
-          # Set environment variables for cross-compilation
-          ENV PKG_CONFIG_ALLOW_CROSS=1
-          ENV PKG_CONFIG_PATH=""
-          ENV PKG_CONFIG_LIBDIR="/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig"
-          ENV PKG_CONFIG_SYSROOT_DIR="/usr/aarch64-linux-gnu"
-          ENV CC_aarch64_unknown_linux_gnu="aarch64-linux-gnu-gcc"
-          ENV CXX_aarch64_unknown_linux_gnu="aarch64-linux-gnu-g++"
-          ENV AR_aarch64_unknown_linux_gnu="aarch64-linux-gnu-ar"
-          ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
-          
+          ENV PATH="${BUN_INSTALL}/bin:$PATH"
+
+          # Install build tools and Tauri dependencies
+          RUN apt-get update && \
+              apt-get install -y --no-install-recommends \
+                build-essential \
+                curl \
+                wget \
+                file \
+                libwebkit2gtk-4.1-dev \
+                libxdo-dev \
+                libssl-dev \
+                libayatana-appindicator3-dev \
+                librsvg2-dev && \
+              rm -rf /var/lib/apt/lists/*
+
+          # Install Tauri CLI
+          RUN cargo install tauri-cli
+
           WORKDIR /project
           EOF
 
-      - name: Build cross-compilation Docker image
+      - name: Build ARM64 app in Docker
         run: |
-          docker build -t tauri-cross -f Dockerfile.cross .
-
-      - name: Build Tauri App for ARM64 using Docker
-        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            --load \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            -t tauri-cross:latest \
+            -f Dockerfile.cross \
+            .
           docker run --rm \
+            --platform linux/arm64 \
+            --user $(id -u):$(id -g) \
             -v $PWD:/project \
-            -v /project/node_modules \
+            -v $HOME/.cargo/registry:/usr/local/cargo/registry \
+            -v $HOME/.cargo/git:/usr/local/cargo/git \
+            -v $PWD/src-tauri/target:/project/src-tauri/target \
+            -v $PWD/node_modules:/project/node_modules \
+            -v $PWD/node_modules:/project/src-tauri/node_modules \
+            -e CARGO_HOME=/usr/local/cargo \
+            -e TAURI_SKIP_BUILD=true \
             -e GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
             tauri-cross \
-            bash -c "
-              cd /project/src-tauri && 
-              cargo tauri build --target aarch64-unknown-linux-gnu --verbose
+            bash -c "\
+              cd /project/src-tauri && \
+              cargo tauri build --target aarch64-unknown-linux-gnu --verbose \
             "
 
       - name: Archive ARM64 build


### PR DESCRIPTION
## Summary
- keep container PATH in ARM64 Docker run so bun and `cargo-tauri` are visible
- run Docker container as the host user so Rust caches can be reused
- install Bun to `/usr/local/bun` so non-root user in container can execute it
- mount host `node_modules` for the Tauri build container
- cache the cross-compilation Docker image layers via Buildx
- warm the ARM64 cargo cache before the final build step
- combine cross-compilation Docker steps into a single build-and-run script
- **build the ARM64 Docker image under the arm64 platform and compile inside that container**

## Testing
- ❌ `cargo test --manifest-path src-tauri/Cargo.toml --locked` *(failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68580757dd58832e8ee41a94978e58b7